### PR TITLE
hh_wealthscore

### DIFF
--- a/15_household.do
+++ b/15_household.do
@@ -30,7 +30,10 @@
     clonevar hh_wealth_quintile = hv270                          
 	
 *hh_wealthscore	Wealth index score   
-    clonevar hh_wealthscore = hv271
+    clonevar hhwealthscore_old = hv271
+    egen hhwealthscore_oldmin=min(hhwealthscore_old) 
+    gen hh_wealthscore=hhwealthscore_old-hhwealthscore_oldmin
+    replace hh_wealthscore=hhwealthscore/1000000
 	 
 
 *hv001 Sampling cluster number (original)


### PR DESCRIPTION
hh_wealthscore updated as the proposed change, where the hh_walthscore should be redefined as in the Adeptfiles instead of directly generated from the raw data. 

Please check and merge the proposed file change if you agreed.